### PR TITLE
refactor: wrap canonical os.ErrNotExist for detect not found error

### DIFF
--- a/pkg/aliyun/drive/drive.go
+++ b/pkg/aliyun/drive/drive.go
@@ -160,6 +160,10 @@ func (drive *Drive) jsonRequest(ctx context.Context, method, url string, request
 	}
 	defer res.Body.Close()
 
+	if res.StatusCode == http.StatusNotFound {
+		return errors.Wrapf(os.ErrNotExist, `failed to request "%s", got "%d"`, url, res.StatusCode)
+	}
+
 	if res.StatusCode >= 400 {
 		return errors.Errorf(`failed to request "%s", got "%d"`, url, res.StatusCode)
 	}
@@ -269,7 +273,7 @@ func (drive *Drive) findNameNode(ctx context.Context, node *Node, name string, k
 		}
 	}
 
-	return nil, errors.Errorf(`can't find "%s", kind: "%s" under "%s"`, name, kind, node)
+	return nil, errors.Wrapf(os.ErrNotExist, `can't find "%s", kind: "%s" under "%s"`, name, kind, node)
 }
 
 // https://help.aliyun.com/document_detail/175927.html#pdsgetfilebypathrequest


### PR DESCRIPTION
Signed-off-by: Jim Ma <majinjing3@gmail.com>

Wrap `os.ErrNotExist` into error, then we can detect error with `errors.Is`. It's useful in `rclone`. 

```
	node, err := f.srv.Get(ctx, path, kind)
	fs.Debugf(nil, "aliyundrive get - path: %q, kind: %s, error: %v", path, kind, err)
	if err != nil {
		if errors.Is(err, os.ErrNotExist) {
			return nil, fs.ErrorObjectNotFound
		}
		return nil, err
	}
```