### PR TITLE
add internal url support

### DIFF
--- a/pkg/aliyun/drive/drive.go
+++ b/pkg/aliyun/drive/drive.go
@@ -60,13 +60,7 @@ var (
 	ErrorLivpUpload     = errors.New("uploading .livp to album is not supported")
 	ErrorAlreadyExisted = errors.New("already existed")
 	ErrorMissingFields  = errors.New("required fields: ParentId, Name")
-
-	UseInternalUrl = false
 )
-
-func init() {
-	UseInternalUrl = os.Getenv("ALIYUN_DRIVE_USE_INTERNAL_URL") == "true"
-}
 
 type Pager interface {
 	Next() bool
@@ -121,6 +115,7 @@ type Config struct {
 	IsAlbum        bool
 	HttpClient     *http.Client
 	OnRefreshToken func(refreshToken string)
+	UseInternalUrl bool
 }
 
 func (config Config) String() string {
@@ -555,7 +550,7 @@ func (drive *Drive) Open(ctx context.Context, nodeId string, headers map[string]
 	}
 
 	url := downloadUrl.Url
-	if UseInternalUrl {
+	if drive.config.UseInternalUrl {
 		url = downloadUrl.InternalUrl
 	}
 	if url != "" {
@@ -708,7 +703,7 @@ func (drive *Drive) CreateFileWithProof(ctx context.Context, node Node, in io.Re
 	for _, part := range proofResult.PartInfoList {
 		partReader := io.LimitReader(in, MaxPartSize)
 		uploadUrl := part.UploadUrl
-		if UseInternalUrl {
+		if drive.config.UseInternalUrl {
 			uploadUrl = part.InternalUploadURL
 		}
 		req, err := http.NewRequestWithContext(ctx, "PUT", uploadUrl, partReader)

--- a/pkg/aliyun/drive/model.go
+++ b/pkg/aliyun/drive/model.go
@@ -70,9 +70,10 @@ type Token struct {
 }
 
 type DownloadUrl struct {
-	Size       int64             `json:"size"`
-	StreamsUrl map[string]string `json:"streams_url,omitempty"`
-	Url        string            `json:"url"`
+	Size        int64             `json:"size"`
+	StreamsUrl  map[string]string `json:"streams_url,omitempty"`
+	Url         string            `json:"url"`
+	InternalUrl string            `json:"internal_url"`
 }
 
 type SharedFile struct {
@@ -106,8 +107,9 @@ type FileProof struct {
 }
 
 type PartInfo struct {
-	PartNumber int    `json:"part_number"`
-	UploadUrl  string `json:"upload_url"`
+	PartNumber        int    `json:"part_number"`
+	UploadUrl         string `json:"upload_url"`
+	InternalUploadURL string `json:"internal_upload_url"`
 }
 
 type ProofResult struct {


### PR DESCRIPTION
支持上传下载走阿里云 ECS 内网。如果跑在阿里云经典网络的 ECS 上可以通过环境变量 `ALIYUN_DRIVE_USE_INTERNAL_URL=true` 开启，开启后上传下载都走阿里云内网，速度快且不计流量。